### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pom.xml.asc
 /target
 package-lock.json
 /server.js
+/bin

--- a/docs/kubectl.sh
+++ b/docs/kubectl.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+beavr::help() {
+  echo "kubectl controls the Kubernetes cluster manager
+
+Usage:
+  kctl get <resource>
+  kctl describe <resource> <id>"
+}
+
+beavr::suggestion() {
+  case "$1" in 
+    "resource") echo "pods nodes deployments" | tr ' ' '\n';;
+    "id") kubectl get $resource | tail -n +2;;
+  esac
+}

--- a/docs/service-curl.sh
+++ b/docs/service-curl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+source "$DIR/work.sh"
+
+beavr::help() {
+  echo "Command for calling an arbitrary URL from a service
+
+Usage:
+  curl [options] <http-method> <prototype> <service> <path>
+  
+Options:
+  -e --env <env>        Infrastructure environment
+  -f --format <format>  Content-type format"
+}
+
+beavr::suggestion() {
+  case "$1" in 
+    "http-method") echo "GET POST PUT PATCH" | tr ' ' '\n';;
+    "prototype") echo "s0 s1 s2 s3 global" | tr ' ' '\n';;
+    "env") echo "staging prod" | tr ' ' '\n';;
+    "--format") echo "xml json yaml edn transit" | tr ' ' '\n';;
+    "service") work services;;
+    "path") work routes "$service" | column -ts ',';;
+  esac
+}

--- a/package.json
+++ b/package.json
@@ -1,11 +1,27 @@
 {
   "name": "beavr",
+  "description": "A command-line autocompleter with steroids",
   "version": "0.1.0",
-  "private": "true",
+  "author": "Denis Isidoro",
+  "repository": "https://github.com/denisidoro/beavr.git",
+  "license": "Apache 2.0",
   "engines": {
-    "node": "6.x"
+    "node": ">=0.9.0"
   },
-  "main": "server.js",
+  "main": "bin/index.js",
+  "preferGlobal": true,
+  "bin": {
+    "beavr": "bin/index.js"
+  },
+  "keywords": [
+    "cli",
+    "autocomplete",
+    "fzf",
+    "clojurescript"
+  ],
+  "files": [
+    "bin"
+  ],
   "dependencies": {
     "neodoc": "^2.0.2",
     "readline-sync": "^1.4.9"
@@ -13,11 +29,5 @@
   "devDependencies": {
     "source-map-support": "^0.4.15",
     "ws": "^1.1.1"
-  },
-  "description": "1. `lein figwheel` 2. (In another window) `node target\\js\\compiled\\docli.js ...`",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "author": "",
-  "license": "ISC"
+  }
 }

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
              {:id "prod"
               :source-paths ["src"]
               :compiler {
-                :output-to "server.js"
+                :output-to "bin/index.js"
                 :output-dir "target/js/compiled/prod"
                 :target :nodejs
                 :optimizations :simple}}]}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject beavr "0.1.0-SNAPSHOT"
-  :description "FIXME: write this!"
-  :url "http://example.com/FIXME"
+  :description "A command-line autocompleter with steroids"
+  :url "https://github.com/denisidoro/beavr"
 
   :min-lein-version "2.7.1"
 

--- a/src/beavr/cmd.cljs
+++ b/src/beavr/cmd.cljs
@@ -1,8 +1,8 @@
 (ns beavr.cmd
-  (:require [beavr.text :as text]
+  (:require [beavr.argument :as arg]
+            [beavr.text :as text]
             [clojure.string :as str]
-            [quark.collection.map :as map]
-            [beavr.argument :as arg]))
+            [quark.collection.map :as map]))
 
 (defn ^:private context-kv->text
   [[k v]]

--- a/src/beavr/core.cljs
+++ b/src/beavr/core.cljs
@@ -1,12 +1,12 @@
 (ns beavr.core
-  (:require [beavr.cmd :as cmd]
+  (:require [beavr.argument :as arg]
+            [beavr.cmd :as cmd]
             [beavr.doc :as doc]
             [beavr.layout :as layout]
             [beavr.prompt :as prompt]
             [beavr.suggestions :as suggestions]
             [beavr.text :as text]
             [cljs.nodejs :as nodejs]
-            [beavr.argument :as arg]
             [clojure.string :as str]))
 
 (nodejs/enable-util-print!)

--- a/src/beavr/doc.cljs
+++ b/src/beavr/doc.cljs
@@ -1,9 +1,9 @@
 (ns beavr.doc
-  (:require [beavr.options :as options]
+  (:require [beavr.argument :as arg]
+            [beavr.options :as options]
+            [beavr.shell :as sh]
             [beavr.text :as text]
-            [clojure.string :as str]
-            [beavr.argument :as arg]
-            [beavr.shell :as sh]))
+            [clojure.string :as str]))
 
 (def neodoc (js/require "neodoc"))
 

--- a/src/beavr/fixtures.cljs
+++ b/src/beavr/fixtures.cljs
@@ -1,7 +1,7 @@
 (ns beavr.fixtures)
 
 (def docstring
-"Naval Fate.
+  "Naval Fate.
 
 Usage:
   naval_fate ship new <name>...

--- a/src/beavr/layout.cljs
+++ b/src/beavr/layout.cljs
@@ -1,7 +1,7 @@
 (ns beavr.layout
-  (:require [clojure.string :as str]
+  (:require [beavr.argument :as arg]
+            [clojure.string :as str]
             [quark.collection.seq :as seq]
-            [beavr.argument :as arg]
             [quark.debug :as debug]))
 
 (defn elem-name

--- a/src/beavr/options.cljs
+++ b/src/beavr/options.cljs
@@ -1,19 +1,19 @@
 (ns beavr.options
-  (:require [beavr.text :as text]
+  (:require [beavr.argument :as arg]
+            [beavr.text :as text]
             [clojure.string :as str]
             [clojure.walk :as walk]
-            [quark.collection.map :as map]
-            [beavr.argument :as arg]))
+            [quark.collection.map :as map]))
 
 (defn from-layout
   [layouts]
   (let [opts (atom [])]
     (walk/prewalk
-      (fn [layout]
-        (when (some-> layout :type (= "Option"))
-          (swap! opts conj layout))
-        layout)
-      layouts)
+     (fn [layout]
+       (when (some-> layout :type (= "Option"))
+         (swap! opts conj layout))
+       layout)
+     layouts)
     (->> @opts
          set
          (map (fn [{:keys [name] :as o}] [name o]))

--- a/src/beavr/prompt.cljs
+++ b/src/beavr/prompt.cljs
@@ -1,25 +1,25 @@
 (ns beavr.prompt
   (:require [beavr.ansi :as ansi]
+            [beavr.argument :as arg]
             [beavr.options :as options]
             [beavr.shell :as sh]
             [beavr.text :as text]
             [clojure.string :as str]
-            [quark.debug :as debug]
-            [beavr.argument :as arg]))
+            [quark.debug :as debug]))
 
 (def ^:private readline-sync (js/require "readline-sync"))
 
 (defn command-str
   [script props]
   (str/join
-    " "
-    (into [script]
-          (map
-            (fn [[k v]]
-              (if v
-                (str (-> k name arg/with-double-dashes) "=" (text/quoted v))
-                (-> k name arg/with-double-dashes)))
-            props))))
+   " "
+   (into [script]
+         (map
+          (fn [[k v]]
+            (if v
+              (str (-> k name arg/with-double-dashes) "=" (text/quoted v))
+              (-> k name arg/with-double-dashes)))
+          props))))
 
 (defn fzf!
   [coll field]

--- a/src/beavr/shell.cljs
+++ b/src/beavr/shell.cljs
@@ -1,7 +1,7 @@
 (ns beavr.shell
-  (:require [clojure.string :as str]
-            [quark.debug :as debug]
-            [beavr.text :as text]))
+  (:require [beavr.text :as text]
+            [clojure.string :as str]
+            [quark.debug :as debug]))
 
 (def ^:private proc (js/require "child_process"))
 (def process (js/require "process"))

--- a/src/beavr/suggestions.cljs
+++ b/src/beavr/suggestions.cljs
@@ -1,11 +1,11 @@
 (ns beavr.suggestions
-  (:require [beavr.layout :as layout]
+  (:require [beavr.argument :as arg]
+            [beavr.layout :as layout]
+            [beavr.shell :as sh]
             [beavr.text :as text]
+            [clojure.string :as str]
             [goog.string :as gstr]
             [goog.string.format]
-            [beavr.shell :as sh]
-            [clojure.string :as str]
-            [beavr.argument :as arg]
             [quark.collection.map :as map]))
 
 (def ^:private ^:const terminate "TERMINATE")
@@ -71,7 +71,7 @@
         format-str (str "%-" length "s")
         format     #(gstr/format format-str %)]
     (map
-      (fn [suggestion comment]
-        (str (format suggestion) comment))
-      suggestions
-      comments)))
+     (fn [suggestion comment]
+       (str (format suggestion) comment))
+     suggestions
+     comments)))

--- a/zsh/widget.zsh
+++ b/zsh/widget.zsh
@@ -1,5 +1,6 @@
 function _beavr_suggestion {
-    zle -U "$(beavr "$CUTBUFFER")"
+    zle kill-whole-line
+    zle -U "$(node "beavr" "$(echo "$CUTBUFFER" | xargs)")"
     zle accept-line
 }
 


### PR DESCRIPTION
# beavr

[![npm version](https://badge.fury.io/js/beavr.svg)](https://badge.fury.io/js/beavr)

<img src="https://user-images.githubusercontent.com/3226564/56245772-95f85c80-6076-11e9-9f86-054231221e1f.png" align="right" />

A command-line autocompleter with steroids.

Based on the target command documentation, it suggests arguments, flags and allows you to select between options with [fzf](https://github.com/junegunn/fzf), a fuzzy-finder.

![Demo](https://user-images.githubusercontent.com/3226564/56243794-d6091080-6071-11e9-8940-9b4c79e66a4e.gif)


## Installation

```terminal
npm install beavr
```


## Usage

It's planned for beavr to infer documentation from the target tool's `--help` content. 

In the meantime, you must define a `<your-cmd>.sh` in `$HOME/.config/beavr/` such as [these examples](https://github.com/denisidoro/beavr/tree/master/docs). 

As of now, they must conform to [Neodoc](https://github.com/felixSchl/neodoc)/[docopt](http://docopt.org/) specifications.


## ZSH widget

Simply source [this file](https://github.com/denisidoro/beavr/blob/master/zsh/widget.zsh) in your `.zshrc`.

By default, the widget is trigged by `Alt + G`.


## Widgets for other shells

While there is no widget for other shells, please run the following:
```terminal
beavr <your-cmd> | pbcopy # or similar clipboard tool
```


## Roadmap

Please refer to [this dashboard](https://github.com/denisidoro/beavr/projects/1).


## Etymology

Command-line call builder > builder > [beaver](https://en.wikipedia.org/wiki/Beaver) > beavr


## Icon

Icon made by [Freepik](https://www.freepik.com) from [flaticon](https://www.flaticon.com) is licensed by [CC 3.0 BY](http://creativecommons.org/licenses/by/3.0/).